### PR TITLE
Only depend on the fabric API modules you need, fix ModMenu in dev env

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,16 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	//modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    //This seems to break runtime with some bullshit about fabric-biomes mixins failing
-    //Which is weird, i thought fabric biomes got crobbed anyways, dunno why this brings it in
-    //Oh well
-    //modCompile "io.github.prospector:modmenu:1.14.6+build.31"
+	// only bring in required fapi modules
+	modImplementation(fabricApi.module("fabric-key-binding-api-v1", project.fabric_version))
+
+	// for modmenu
+	modImplementation(fabricApi.module("fabric-resource-loader-v0", project.fabric_version))
+	modImplementation("io.github.prospector:modmenu:1.14.6+build.31") {
+		exclude module: 'fabric-api' // modmenu brings in bad fapi
+	}
 }
 
 processResources {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
 
   "depends": {
     "fabricloader": ">=0.7.4",
-    "fabric": "*",
+    "fabric-key-binding-api-v1": "*",
     "minecraft": "1.16.x"
   },
   "suggests": {


### PR DESCRIPTION
The reason ModMenu was causing Mixin to scream in pain is because it depends on a horribly outdated version of Fabric API that doesn't even work in the newest versions of MC. By preventing it from pulling in that dependency, and simply providing a working version yourself, ModMenu will work just fine.

Additionally, there's no need to pull in the entirety of Fabric API if all you need is the key binding API. Likewise, there's no need to declare your dependency on the entirety of Fabric API if all you *really* need is the key binding API.

It's a convenience during development to have the entire API available (as a gradle dependency), but on release you should identify which modules you use and depend on those modules specifically instead of `fabric`. ModMenu does this with fabric-resource-loader-v0, and with this commit RebindNarrator will only require fabric-key-binding-api-v1.